### PR TITLE
Address upstream `@types/react` issue

### DIFF
--- a/src/app/plugins/platform/JavaScript/templates/tsconfig.json
+++ b/src/app/plugins/platform/JavaScript/templates/tsconfig.json
@@ -16,7 +16,7 @@
     "importHelpers": true,
     "jsx": "preserve",
 
-    "lib": ["dom", "es5", "es2015.promise"]
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection"]
   },
 
   "include": ["src/**/*.tsx", "src/**/*.ts"]


### PR DESCRIPTION
We are still aiming largely for IE11 compat, so we aren't bumping the
target lib version (yet) up to 2015 - just adding collection typings.