### PR TITLE
Fix webpack scaffold

### DIFF
--- a/src/app/plugins/platform/JavaScript/index.ts
+++ b/src/app/plugins/platform/JavaScript/index.ts
@@ -174,12 +174,6 @@ class JavaScript extends Generator {
 
     this._installToolchain();
     this._installDependencies();
-
-    this.installDependencies({
-      npm: true,
-      bower: false,
-      yarn: false,
-    });
   }
 }
 

--- a/src/app/plugins/platform/JavaScript/templates/webpack.config.js
+++ b/src/app/plugins/platform/JavaScript/templates/webpack.config.js
@@ -214,12 +214,12 @@ module.exports = {
             loader: 'css-loader',
             options: {
               sourceMap: isDevelopment,
-              modules: useCSSModules,
-
-              // Include local path in hashed classes. This only applies to CSS modules.
-              localIdentName: isDevelopment
-                ? '[path]__[local]__[hash:base64:5]'
-                : '[hash:base64]',
+              modules: useCSSModules && {
+                // Include local path in hashed classes. This only applies to CSS modules.
+                localIdentName: isDevelopment
+                  ? '[path]__[local]__[hash:base64:5]'
+                  : '[hash:base64]',
+              },
 
               // Ensures postcss-loader and sass-loader see any modules imported via the 'composes'
               // directive (This only applies in CSS modules mode, and is not needed for regular

--- a/src/app/plugins/platform/JavaScript/templates/webpack.config.js
+++ b/src/app/plugins/platform/JavaScript/templates/webpack.config.js
@@ -25,7 +25,7 @@ const useCSSModules = false;
 
 // It shouldn't be necessary to edit anything below this line.
 
-const CleanWebpackPlugin = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractCssChunksPlugin = require('extract-css-chunks-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
@@ -61,7 +61,7 @@ const targetDirectory = path.join(__dirname, 'public');
 // We always use these plugins
 const plugins = [
   // Remove stale build output
-  new CleanWebpackPlugin([targetDirectory]),
+  new CleanWebpackPlugin(),
 
   // Create separate CSS stylesheets
   new ExtractCssChunksPlugin({


### PR DESCRIPTION
This addresses a few issues that have accumulated with the Webpack SPA scaffolding:

* We don't double-invoke `npm install` anymore.
* `CleanWebpackPlugin` 3.0 is now a property of the module, not its sole export. In addition, the options schema changed.
* `css-loader`'s `localIdentName` is now a property of the `modules` object, not a top-level loader option.