### PR TITLE
[DEVTOOLS-286] Fix Drupal 8 Capistrano deploy

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -124,7 +124,9 @@ class Drupal8 extends Generator {
         config: {
           drupal_features: false,
         },
-        linkedDirectories: ['services/drupal/sites/default/files'],
+        linkedDirectories: [
+          posix.join('services/drupal', documentRoot, '/sites/default/files'),
+        ],
         linkedFiles: ['services/drupal/.env'],
       });
     }

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -125,7 +125,7 @@ class Drupal8 extends Generator {
           drupal_features: false,
         },
         linkedDirectories: [
-          posix.join('services/drupal', documentRoot, '/sites/default/files'),
+          posix.join('services/drupal', documentRoot, 'sites/default/files'),
         ],
         linkedFiles: ['services/drupal/.env'],
       });


### PR DESCRIPTION
Update linkedDirectories to include the Drupal documentRoot so the generated debloy.rb file adds the correct public files path to Capistrano `linked_dirs`.