### PR TITLE
Add template for wp-cli.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Editor stuff
 .vscode
+.idea
 
 # NPM
 node_modules

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -271,6 +271,15 @@ class WordPress extends Generator {
       this.destinationPath('services/wordpress/.dockerignore'),
       ignore.serialize(),
     );
+
+    // For projects NOT using the web-starter, add a wp-cli.yml file.
+    if (!this.usesWpStarter) {
+      this.fs.copyTpl(
+        this.templatePath('wp-cli-nostarter.yml.ejs'),
+        this.destinationPath('services/wordpress/wp-cli.yml'),
+        { documentRoot: this.documentRoot },
+      );
+    }
   }
 
   private async _installWordPress() {

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/templates/wp-cli-nostarter.yml.ejs
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/templates/wp-cli-nostarter.yml.ejs
@@ -1,0 +1,1 @@
+path: ./<%= documentRoot %>


### PR DESCRIPTION
As discussed in DEVTOOLS-281, WordPress projects that don't use the wp-starter need a wp-cli.yml file showing WP-CLI where the document root is for `f1 wp` commands to work.