### PR TITLE
Fix infinite redirect loops

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/templates/nginx.conf.ejs
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/templates/nginx.conf.ejs
@@ -10,7 +10,7 @@ server {
 
   index index.php index.html;
   location / {
-    try_files $uri /index.php?$query_string;
+    try_files $uri $uri/ /index.php?$query_string;
   }
 
   location @rewrite {

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/templates/nginx.conf.ejs
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/templates/nginx.conf.ejs
@@ -10,7 +10,7 @@ server {
 
   index index.php index.html;
   location / {
-    try_files $uri $uri/ @rewrite;
+    try_files $uri /index.php?$query_string;
   }
 
   location @rewrite {


### PR DESCRIPTION
This addresses a bug in the default nginx configuration where enabling the Drupal 8 `redirect` module would trigger an infinite redirect loop.