### PR TITLE
Expose platform configuration in Composer files

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/createComposerFile.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/createComposerFile.ts
@@ -9,8 +9,13 @@ export interface Require {
   readonly [pkg: string]: string;
 }
 
+export interface Platform {
+  readonly [extension: string]: string;
+}
+
 export interface Config {
   readonly 'vendor-dir': string;
+  readonly platform?: Platform;
 }
 
 const runWPStarterSetup = 'WCM\\WPStarter\\Setup::run';
@@ -72,6 +77,12 @@ function createComposerFile(name: string, documentRoot: string): ComposerFile {
     },
     config: {
       'vendor-dir': vendorDirectory,
+      platform: {
+        // Inform composer that the production environment will have the mysqli extension.
+        // The number here is completely arbitrary and has no meaning outside of being a
+        // valid semver version. Composer does not check this number, only that it exists.
+        'ext-mysqli': '1.0.0'
+      }
     },
     scripts: {
       'post-install-cmd': runWPStarterSetup,

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -289,9 +289,7 @@ class WordPress extends Generator {
 
     if (this.usesWpStarter) {
       const wpRoot = this.destinationPath('services/wordpress');
-      await spawnComposer(['install', '--ignore-platform-reqs'], {
-        cwd: wpRoot,
-      });
+      await spawnComposer(['install'], { cwd: wpRoot });
     } else {
       const wpRoot = this.destinationPath(
         'services/wordpress',


### PR DESCRIPTION
This PR adds [platform information](https://getcomposer.org/doc/06-config.md#platform) to any `composer.json` files emitted by the generator. For WordPress projects, we advertise the `mysql` extension, and for Drupal 8, we expose `gd`, `opcache`, and `pdo`.

For users, this means that `f1 composer install` now works as expected, despite the fact that Composer is run in a container that does not have access to the Drupal/WordPress image's installed extensions.