### PR TITLE
WP/PHP improvements + refactoring

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ function lint() {
   return gulp
     .src(typescriptSources, { since: gulp.lastRun(lint) })
     .pipe(eslint({ formatter: 'codeFrame' }))
+    .pipe(eslint.failAfterError())
     .pipe(eslint.format());
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,8 +28,8 @@ function lint() {
   return gulp
     .src(typescriptSources, { since: gulp.lastRun(lint) })
     .pipe(eslint({ formatter: 'codeFrame' }))
-    .pipe(eslint.failAfterError())
-    .pipe(eslint.format());
+    .pipe(eslint.format())
+    .pipe(eslint.failAfterError());
 }
 
 function copy() {

--- a/src/app/plugins/platform/Docker/dockerfile/Dependency.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/Dependency.ts
@@ -10,9 +10,9 @@ interface Dependency {
   readonly builtins?: ReadonlyArray<string>;
 
   /**
-   * The args needed to configure this dependency.
+   * The command used to configure this dependency.
    */
-  readonly configureArgs?: ReadonlyArray<string>;
+  readonly configureCommand?: ReadonlyArray<string>;
 
   /**
    * If this dependency represents a PECL package, should it be enabled by default

--- a/src/app/plugins/platform/Docker/dockerfile/Dependency.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/Dependency.ts
@@ -1,0 +1,39 @@
+/**
+ * A `Dependency` object represents one or more PHP dependencies to be installed into
+ * an image. This abstracts away from the machinery used to install a package regardless
+ * of its source.
+ */
+interface Dependency {
+  /**
+   * Which PHP builtin(s) this dependency represents.
+   */
+  readonly builtins?: ReadonlyArray<string>;
+
+  /**
+   * The args needed to configure this dependency.
+   */
+  readonly configureArgs?: ReadonlyArray<string>;
+
+  /**
+   * If this dependency represents a PECL package, should it be enabled by default
+   * in the image?
+   *
+   * This option defaults to `true` and exists largely to support the case of installing
+   * XDebug - if that package is enabled by default, there is a significant performance
+   * penalty for all site requests, even if the user isn't engaged in a debugging
+   * session.
+   */
+  readonly defaultEnabled?: boolean;
+
+  /**
+   * Alpine packages needed to install to build/run this dependency.
+   */
+  readonly packages?: ReadonlyArray<string>;
+
+  /**
+   * PECL packages to be installed for this dependency.
+   */
+  readonly pecl?: ReadonlyArray<string>;
+}
+
+export default Dependency;

--- a/src/app/plugins/platform/Docker/dockerfile/DockerfileDependencies.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/DockerfileDependencies.ts
@@ -1,0 +1,43 @@
+/**
+ * Describes a PECL package to be installed into a Docker image.
+ */
+export interface PeclPackage {
+  /**
+   * The name of the PECL package.
+   */
+  name: string;
+
+  /**
+   * Whether or not to enable this package by default in the image.
+   */
+  enabled: boolean;
+}
+
+/**
+ * This interface represents the aggregated commands and packages needed by the list of
+ * dependencies passed to `createPHPDockerfile()`. The values here are mostly intended
+ * to be used as the list of things to analyze
+ */
+interface DockerfileDependencies {
+  /**
+   * Alpine packages needed by this array of dependencies.
+   */
+  readonly alpinePackages: ReadonlyArray<string>;
+
+  /**
+   * Arrays of commands to configure these dependencies.
+   */
+  readonly configureCommands: ReadonlyArray<ReadonlyArray<string>>;
+
+  /**
+   * The names of all builtin extensions needed for these dependencies.
+   */
+  readonly builtinExtensions: ReadonlyArray<string>;
+
+  /**
+   * The PECL packages needed for these dependencies.
+   */
+  readonly peclPackages: ReadonlyArray<PeclPackage>;
+}
+
+export default DockerfileDependencies;

--- a/src/app/plugins/platform/Docker/dockerfile/computeDependencyBuildCommand.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/computeDependencyBuildCommand.ts
@@ -1,0 +1,84 @@
+import Dependency from './Dependency';
+import computeDockerfileDependencies from './computeDockerfileDependencies';
+
+// Command used to scan run-time dependencies and save the names in the $runDeps variable
+const runDepsCommand = `runDeps="$(\\
+  scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \\
+    | tr ',' '\\n' \\
+    | sort -u \\
+    | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \\
+  )"`;
+
+/**
+ * Returns the list of commands suitable for injecting into a Docker `RUN` statement
+ *
+ * @param dependencies
+ */
+function computeDependencyBuildCommand(
+  dependencies: ReadonlyArray<Dependency>,
+): ReadonlyArray<string | ReadonlyArray<string>> {
+  const {
+    alpinePackages,
+    builtinExtensions,
+    configureCommands,
+    peclPackages,
+  } = computeDockerfileDependencies(dependencies);
+
+  const hasBuiltins = builtinExtensions.length > 0;
+  const hasPeclPackages = peclPackages.length > 0;
+  const shouldSaveRunDeps = hasBuiltins || hasPeclPackages;
+
+  const command: Array<string | ReadonlyArray<string>> = [];
+
+  // First, install all build dependencies
+  command.push([
+    'apk',
+    'add',
+    '--no-cache',
+    '--virtual',
+    '.build-deps',
+    '$PHPIZE_DEPS',
+    ...alpinePackages,
+  ]);
+
+  // Run configure for any extensions
+  for (const configureCommand of configureCommands) {
+    command.push(['docker-php-ext-configure', ...configureCommand]);
+  }
+
+  // Install builtins
+  if (hasBuiltins) {
+    command.push([
+      'docker-php-ext-install',
+      '-j',
+      '$(nproc)',
+      ...builtinExtensions,
+    ]);
+  }
+
+  // Install PECL packages
+  for (const { enabled, name } of peclPackages) {
+    command.push(['pecl', 'install', name]);
+    if (enabled) {
+      command.push(['docker-php-ext-enable', name]);
+    }
+  }
+
+  // Scan runtime dependencies and force apk to save them in the resulting image
+  if (shouldSaveRunDeps) {
+    command.push(runDepsCommand, [
+      'apk',
+      'add',
+      '--virtual',
+      '.docker-phpexts-rundeps',
+      '$runDeps',
+    ]);
+  }
+
+  // Remove all build-time dependencies
+  command.push(['apk', 'del', '.build-deps']);
+
+  return command;
+}
+
+export default computeDependencyBuildCommand;

--- a/src/app/plugins/platform/Docker/dockerfile/computeDockerfileDependencies.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/computeDockerfileDependencies.ts
@@ -1,0 +1,54 @@
+import Dependency from './Dependency';
+import DockerfileDependencies, { PeclPackage } from './DockerfileDependencies';
+
+/**
+ * Computes low-level dependencies for a Dockerfile build. This function is responsible
+ * for taking high-level `Dependency` objects and converting them into the low-level
+ * elements (Alpine packages needed for `apk add`, lists of configure commands, etc.)
+ * that are used in generating an image.
+ *
+ * @param dependencies Array of PHP packages (PECL or builtin) this image depends on
+ */
+function computeDockerfileDependencies(
+  dependencies: ReadonlyArray<Dependency>,
+): DockerfileDependencies {
+  const alpinePackages: string[] = [];
+  const configureCommands: ReadonlyArray<string>[] = [];
+  const builtinExtensions: string[] = [];
+  const peclPackages: PeclPackage[] = [];
+
+  for (const dependency of dependencies) {
+    if (dependency.packages) {
+      alpinePackages.push(...dependency.packages);
+    }
+
+    if (dependency.configureCommand) {
+      configureCommands.push(dependency.configureCommand);
+    }
+
+    if (dependency.builtins) {
+      builtinExtensions.push(...dependency.builtins);
+    }
+
+    if (dependency.pecl) {
+      const { defaultEnabled = true } = dependency;
+      const additionalPackages = dependency.pecl.map(
+        (name): PeclPackage => ({
+          enabled: defaultEnabled,
+          name,
+        }),
+      );
+
+      peclPackages.push(...additionalPackages);
+    }
+  }
+
+  return {
+    alpinePackages,
+    builtinExtensions,
+    configureCommands,
+    peclPackages,
+  };
+}
+
+export default computeDockerfileDependencies;

--- a/src/app/plugins/platform/Docker/dockerfile/createPHPDockerfile.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/createPHPDockerfile.ts
@@ -8,6 +8,7 @@ export interface CreatePHPDockerfileOptions {
   peclPackages?: ReadonlyArray<string>;
   runtimeDeps?: ReadonlyArray<string>;
   postBuildCommands?: ReadonlyArray<string | ReadonlyArray<string>>;
+  user?: string;
   xdebug?: boolean;
 }
 
@@ -26,6 +27,7 @@ function createPHPDockerfile({
   peclPackages = [],
   postBuildCommands = [],
   runtimeDeps = [],
+  user,
   xdebug,
 }: CreatePHPDockerfileOptions): Dockerfile {
   const command: Array<string | ReadonlyArray<string>> = [['set', '-ex']];
@@ -86,7 +88,19 @@ function createPHPDockerfile({
   // Allow post-build setup
   command.push(...postBuildCommands);
 
-  return new Dockerfile().from(from).run({ command });
+  const dockerfile = new Dockerfile().from(from);
+
+  if (user) {
+    dockerfile.user('root');
+  }
+
+  dockerfile.run({ command });
+
+  if (user) {
+    dockerfile.user(user);
+  }
+
+  return dockerfile;
 }
 
 export default createPHPDockerfile;

--- a/src/app/plugins/platform/Docker/dockerfile/createPHPDockerfile.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/createPHPDockerfile.ts
@@ -1,6 +1,7 @@
 import { Dockerfile, From } from 'dockerfilejs';
 
 import Dependency from './Dependency';
+import computeDependencyBuildCommand from './computeDependencyBuildCommand';
 
 /**
  * Options needed to create a `Dockerfile` object for a PHP-based image.
@@ -33,27 +34,6 @@ export interface CreatePHPDockerfileOptions {
   user?: string;
 }
 
-const runDepsCommand = `runDeps="$(\\
-    scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \\
-      | tr ',' '\\n' \\
-      | sort -u \\
-      | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \\
-  )"`;
-
-/**
- * Helper type used in `createPHPDockerfile()`.
- */
-interface PeclPackage {
-  /**
-   * The name of the PECL package.
-   */
-  name: string;
-  /**
-   * Whether or not to enable it by default in the image.
-   */
-  enabled: boolean;
-}
-
 function createPHPDockerfile({
   from,
   dependencies = [],
@@ -61,86 +41,21 @@ function createPHPDockerfile({
   runtimeDeps = [],
   user,
 }: CreatePHPDockerfileOptions): Dockerfile {
+  const buildCommand = computeDependencyBuildCommand(dependencies);
+
+  // Use string[][] to allow more straightforward spreading
+  const runtimeCommands =
+    runtimeDeps.length > 0
+      ? [['apk', 'add', '--no-cache', ...runtimeDeps]]
+      : [];
+
   const command: Array<string | ReadonlyArray<string>> = [['set', '-ex']];
 
-  const buildDeps: string[] = [];
-  const configureArgs: ReadonlyArray<string>[] = [];
-  const builtins: string[] = [];
-  const peclPackages: PeclPackage[] = [];
+  // Add computed build command(s)
+  command.push(...buildCommand);
 
-  for (const dependency of dependencies) {
-    if (dependency.packages) {
-      buildDeps.push(...dependency.packages);
-    }
-
-    if (dependency.configureArgs) {
-      configureArgs.push(dependency.configureArgs);
-    }
-
-    if (dependency.builtins) {
-      builtins.push(...dependency.builtins);
-    }
-
-    if (dependency.pecl) {
-      const { defaultEnabled = true } = dependency;
-      const additionalPackages = dependency.pecl.map(
-        (name): PeclPackage => ({
-          enabled: defaultEnabled,
-          name,
-        }),
-      );
-
-      peclPackages.push(...additionalPackages);
-    }
-  }
-
-  // First, install all build dependencies
-  command.push([
-    'apk',
-    'add',
-    '--no-cache',
-    '--virtual',
-    '.build-deps',
-    '$PHPIZE_DEPS',
-    ...buildDeps,
-  ]);
-
-  // Run configure for any extensions
-  for (const configureArg of configureArgs) {
-    command.push(['docker-php-ext-configure', ...configureArg]);
-  }
-
-  // Install builtins
-  if (builtins.length !== 0) {
-    command.push(['docker-php-ext-install', '-j', '$(nproc)', ...builtins]);
-  }
-
-  for (const { enabled, name } of peclPackages) {
-    command.push(['pecl', 'install', name]);
-
-    if (enabled) {
-      command.push(['docker-php-ext-enable', name]);
-    }
-  }
-
-  // Scan runtime dependencies and force apk to save them in the resulting image
-  if (builtins.length !== 0 || peclPackages.length > 0) {
-    command.push(runDepsCommand, [
-      'apk',
-      'add',
-      '--virtual',
-      '.docker-phpexts-rundeps',
-      '$runDeps',
-    ]);
-  }
-
-  // Remove all build-time dependencies
-  command.push(['apk', 'del', '.build-deps']);
-
-  // Add any runtime dependencies (mostly used for building e.g., drush)
-  if (runtimeDeps.length !== 0) {
-    command.push(['apk', 'add', '--no-cache', ...runtimeDeps]);
-  }
+  // Add any runtime dependencies (e.g., SSH for Drush/WP-CLI)
+  command.push(...runtimeCommands);
 
   // Allow post-build setup
   command.push(...postBuildCommands);

--- a/src/app/plugins/platform/Docker/dockerfile/gd.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/gd.ts
@@ -1,0 +1,14 @@
+import Dependency from './Dependency';
+
+const gd: Dependency = {
+  builtins: ['gd'],
+  configureArgs: [
+    'gd',
+    '--with-freetype-dir=/usr/include/',
+    '--with-jpeg-dir=/usr/include/',
+    '--with-png-dir=/usr/include/',
+  ],
+  packages: ['coreutils', 'freetype-dev', 'libjpeg-turbo-dev'],
+};
+
+export default gd;

--- a/src/app/plugins/platform/Docker/dockerfile/gd.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/gd.ts
@@ -2,7 +2,7 @@ import Dependency from './Dependency';
 
 const gd: Dependency = {
   builtins: ['gd'],
-  configureArgs: [
+  configureCommand: [
     'gd',
     '--with-freetype-dir=/usr/include/',
     '--with-jpeg-dir=/usr/include/',

--- a/src/app/plugins/platform/Docker/dockerfile/memcached.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/memcached.ts
@@ -1,0 +1,7 @@
+export const memcachedDependencies: ReadonlyArray<string> = [
+  'libmemcached-dev',
+  'zlib-dev',
+  'libevent-dev',
+];
+
+export const memcachedPackages: ReadonlyArray<string> = ['memcached'];

--- a/src/app/plugins/platform/Docker/dockerfile/memcached.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/memcached.ts
@@ -1,7 +1,8 @@
-export const memcachedDependencies: ReadonlyArray<string> = [
-  'libmemcached-dev',
-  'zlib-dev',
-  'libevent-dev',
-];
+import Dependency from './Dependency';
 
-export const memcachedPackages: ReadonlyArray<string> = ['memcached'];
+const memcached: Dependency = {
+  packages: ['libmemcached-dev', 'zlib-dev', 'libevent-dev'],
+  pecl: ['memcached'],
+};
+
+export default memcached;

--- a/src/app/plugins/platform/Docker/dockerfile/opcache.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/opcache.ts
@@ -1,0 +1,7 @@
+import Dependency from './Dependency';
+
+const opcache: Dependency = {
+  builtins: ['opcache'],
+};
+
+export default opcache;

--- a/src/app/plugins/platform/Docker/dockerfile/pdo.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/pdo.ts
@@ -1,0 +1,8 @@
+import Dependency from './Dependency';
+
+const pdo: Dependency = {
+  builtins: ['pdo_mysql', 'pdo_pgsql'],
+  packages: ['postgresql-dev'],
+};
+
+export default pdo;

--- a/src/app/plugins/platform/Docker/dockerfile/xdebug.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/xdebug.ts
@@ -1,0 +1,8 @@
+import Dependency from './Dependency';
+
+const xdebug: Dependency = {
+  defaultEnabled: false,
+  pecl: ['xdebug'],
+};
+
+export default xdebug;

--- a/src/app/plugins/platform/Docker/dockerfile/zip.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/zip.ts
@@ -1,0 +1,8 @@
+import Dependency from './Dependency';
+
+const zip: Dependency = {
+  builtins: ['zip'],
+  packages: ['libzip-dev'],
+};
+
+export default zip;

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -5,10 +5,11 @@ import Generator from 'yeoman-generator';
 import IgnoreEditor from '../../../../../../IgnoreEditor';
 import ComposeEditor, { createBindMount } from '../../../ComposeEditor';
 import createPHPDockerfile from '../../../dockerfile/createPHPDockerfile';
-import {
-  memcachedDependencies,
-  memcachedPackages,
-} from '../../../dockerfile/memcached';
+import gd from '../../../dockerfile/gd';
+import memcached from '../../../dockerfile/memcached';
+import opcache from '../../../dockerfile/opcache';
+import pdo from '../../../dockerfile/pdo';
+import zip from '../../../dockerfile/zip';
 import getLatestDrupalTag from '../../../registry/getLatestDrupalTag';
 import getLatestPhpCliAlpineTag from '../../../registry/getLatestPhpCliAlpineTag';
 import spawnComposer from '../../../spawnComposer';
@@ -277,39 +278,19 @@ class Drupal8 extends Generator {
 
   writing() {
     const needsMemcached = this.options.plugins.cache === 'Memcache';
-    const sharedDependencies = needsMemcached ? memcachedDependencies : [];
-
-    const sharedPeclPackages = needsMemcached ? memcachedPackages : [];
+    const sharedDependencies = needsMemcached ? [memcached] : [];
+    sharedDependencies.push(opcache);
 
     const drupalDockerfile = createPHPDockerfile({
       from: { image: 'drupal', tag: this.latestDrupalTag },
-      buildDeps: sharedDependencies,
-      peclPackages: sharedPeclPackages,
-      xdebug: true,
+      dependencies: sharedDependencies,
     });
 
-    // "borrowed" from library/drupal's Dockerfile
-    const drupalDependencies = [
-      'coreutils',
-      'freetype-dev',
-      'libjpeg-turbo-dev',
-      'postgresql-dev',
-      'libzip-dev',
-    ];
+    const drupalDependencies = [gd, pdo, zip];
 
     const drushDockerfile = createPHPDockerfile({
       from: { image: 'php', tag: this.latestPhpTag },
-      buildDeps: [...drupalDependencies, ...sharedDependencies],
-      builtins: ['gd', 'opcache', 'pdo_mysql', 'pdo_pgsql', 'zip'],
-      configureArgs: [
-        [
-          'gd',
-          '--with-freetype-dir=/usr/include/',
-          '--with-jpeg-dir=/usr/include/',
-          '--with-png-dir=/usr/include/',
-        ],
-      ],
-      peclPackages: sharedPeclPackages,
+      dependencies: [...drupalDependencies, ...sharedDependencies],
       // The memory limit defaults to 128M, even in CLI containers - expand it for easier
       // developer use.
       postBuildCommands: [

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/createComposerFile.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/createComposerFile.ts
@@ -81,8 +81,8 @@ function createComposerFile(name: string, documentRoot: string): ComposerFile {
         // Inform composer that the production environment will have the mysqli extension.
         // The number here is completely arbitrary and has no meaning outside of being a
         // valid semver version. Composer does not check this number, only that it exists.
-        'ext-mysqli': '1.0.0'
-      }
+        'ext-mysqli': '1.0.0',
+      },
     },
     scripts: {
       'post-install-cmd': runWPStarterSetup,


### PR DESCRIPTION
This includes a few fixes found while addressing the WP-CLI SSH functionality:

1. A custom WP-CLI image is now built for WordPress projects.
2. The memory limit in WP-CLI containers is now -1.
3. The memcached extension is installed for WordPress projects when the plugin is enabled.
4. The `createPHPDockerfile()` function has been refactored to use a higher-level abstraction for dependencies.
5. Lint failures are propagated into Gulp build failures.