### PR TITLE
Allow large cache tag headers

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/templates/nginx.conf.ejs
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/templates/nginx.conf.ejs
@@ -22,6 +22,8 @@ server {
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     include fastcgi_params;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
     fastcgi_intercept_errors on;
     fastcgi_pass drupal:9000;
   }


### PR DESCRIPTION
This PR increases the size of the FastCGI buffers for Drupal projects in order to account for the sometimes-large cache tag headers that Drupal 8 returns.