### PR TITLE
Update methodology for identifying working directory for drush

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -225,7 +225,8 @@ class Drupal8 extends Generator {
       build: './services/drush',
       // Pass --root to the entrypoint so that Drush can both see the full Drupal
       // install and know where the site's root actually is.
-      entrypoint: ['/var/www/html/vendor/bin/drush', `--root=${varHtmlPath}`],
+      entrypoint: ['/var/www/html/vendor/bin/drush'],
+      working_dir: varHtmlPath,
       volumes: [
         createBindMount('./services/drupal', '/var/www/html'),
         {


### PR DESCRIPTION
Updating docker-compose.cli to use working_dir to establish where drush is run from instead of utilizing --root parameter on drush because it overrides aliases attempting to stipulate their own root on remotes.