### PR TITLE
Enabling xdebug pecl extension dependency by default on drupal container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npx --ignore-existing -p yo -p generator-web-starter yo web-starter
 ## Enhancing this project / Setup instructions
 
 - Clone repository
-- `npm install` - install dependencies
+- `npm ci` - install dependencies
 - Perform changes
 - `npm pack` - Create a tarball for testing purposes
 - `npx -p <path to generator.tgz> -p yo -- yo web-starter`  - Execute web starter with the modifications you just made

--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ This command will temporarily install [`yo`](https://www.npmjs.com/package/yo) -
 ```sh
 npx --ignore-existing -p yo -p generator-web-starter yo web-starter
 ```
+
+## Enhancing this project / Setup instructions
+
+- Clone repository
+- `npm install` - install dependencies
+- Perform changes
+- `npm pack` - Create a tarball for testing purposes
+- `npx -p <path to generator.tgz> -p yo -- yo web-starter`  - Execute web starter with the modifications you just made
+- Review input / output after making selections that you're testing for and ensure changes are captured

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -279,10 +279,11 @@ class Drupal8 extends Generator {
   }
 
   writing() {
+    const sharedDependencies = [xdebug, opcache];
     const needsMemcached = this.options.plugins.cache === 'Memcache';
-    const sharedDependencies = needsMemcached ? [memcached] : [];
-    sharedDependencies.push(xdebug);
-    sharedDependencies.push(opcache);
+    if (needsMemcached) {
+      sharedDependencies.push(memcached);
+    }
 
     const drupalDockerfile = createPHPDockerfile({
       from: { image: 'drupal', tag: this.latestDrupalTag },

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -14,6 +14,7 @@ import getLatestDrupalTag from '../../../registry/getLatestDrupalTag';
 import getLatestPhpCliAlpineTag from '../../../registry/getLatestPhpCliAlpineTag';
 import spawnComposer from '../../../spawnComposer';
 import { enableXdebug, xdebugEnvironment } from '../../../xdebug';
+import xdebug from '../../../dockerfile/xdebug';
 
 import installDrupal, {
   drupalProject,
@@ -280,6 +281,7 @@ class Drupal8 extends Generator {
   writing() {
     const needsMemcached = this.options.plugins.cache === 'Memcache';
     const sharedDependencies = needsMemcached ? [memcached] : [];
+    sharedDependencies.push(xdebug);
     sharedDependencies.push(opcache);
 
     const drupalDockerfile = createPHPDockerfile({


### PR DESCRIPTION
Also added a bit of text to the README so I don't have to look up these instructions in the future.