### PR TITLE
Switch to Composer 1.9

### DIFF
--- a/src/app/plugins/platform/Docker/ComposeEditor/index.ts
+++ b/src/app/plugins/platform/Docker/ComposeEditor/index.ts
@@ -136,7 +136,7 @@ class ComposeEditor {
 
   addNamedComposer(name: string, directory: string) {
     this.addService(name, {
-      image: 'composer:1.7',
+      image: 'forumone/composer:1.9',
       volumes: [createBindMount(`./${directory}`, '/app')],
     });
   }

--- a/src/app/plugins/platform/Docker/spawnComposer.ts
+++ b/src/app/plugins/platform/Docker/spawnComposer.ts
@@ -59,7 +59,7 @@ async function spawnComposer(
       '-it',
       ...userOptions,
       ...mountOptions,
-      'composer:1.7',
+      'forumone/composer:1.9',
       ...args,
     ],
     {


### PR DESCRIPTION
This bumps the Composer version used by new projects to 1.9, as required by Drupal 8.8.