### PR TITLE
Assist profiling PHP requests

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -7,7 +7,11 @@ import ComposeEditor, { createBindMount } from '../../../ComposeEditor';
 import getLatestDrupal8Tag from '../../../registry/getLatestDrupal8Tag';
 import getLatestDrupal8CliTag from '../../../registry/getLatestDrupal8CliTag';
 import spawnComposer from '../../../spawnComposer';
-import { enableXdebug, xdebugEnvironment } from '../../../xdebug';
+import {
+  enableXdebug,
+  enableXdebugProfiler,
+  xdebugEnvironment,
+} from '../../../xdebug';
 
 import installDrupal, {
   drupalProject,
@@ -196,6 +200,7 @@ class Drupal8 extends Generator {
     const drupalEntryCommand = [
       `chmod -R 0777 ${uploadPath}`,
       enableXdebug,
+      enableXdebugProfiler,
       'exec php-fpm',
     ].join('\n');
 

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -10,7 +10,11 @@ import ComposeEditor, { createBindMount } from '../../../ComposeEditor';
 import getLatestWordPressCliTag from '../../../registry/getLatestWordPressCliTag';
 import getLatestWordPressTag from '../../../registry/getLatestWordPressTag';
 import spawnComposer from '../../../spawnComposer';
-import { enableXdebug, xdebugEnvironment } from '../../../xdebug';
+import {
+  enableXdebug,
+  enableXdebugProfiler,
+  xdebugEnvironment,
+} from '../../../xdebug';
 
 import createComposerFile from './createComposerFile';
 import getHashes from './getHashes';
@@ -189,6 +193,7 @@ class WordPress extends Generator {
     const wpEntryCommand = [
       `chmod -R 0777 ${uploadPath}`,
       enableXdebug,
+      enableXdebugProfiler,
       'exec php-fpm',
     ].join('\n');
 

--- a/src/app/plugins/platform/Docker/xdebug.ts
+++ b/src/app/plugins/platform/Docker/xdebug.ts
@@ -1,9 +1,22 @@
 import dedent from 'dedent';
 
+// http://xdebug.org/docs/all_settings#remote_enable
 export const enableXdebug = dedent(`
   if test ! -z "\${F1_XDEBUG:-}"; then
     docker-php-ext-enable xdebug
     echo 'xdebug.remote_enable=1' > /usr/local/etc/php/conf.d/xdebug.ini
+  fi
+`);
+
+// http://xdebug.org/docs/all_settings#profiler_enable_trigger
+export const enableXdebugProfiler = dedent(`
+  if test ! -z "\${F1_XDEBUG_PROFILER:-}"; then
+    docker-php-ext-enable xdebug
+    mkdir /var/www/html/_profiles
+    chmod -R 0777 /var/www/html/_profiles
+    echo 'xdebug.profiler_enable_trigger=1' > /usr/local/etc/php/conf.d/xdebug.ini
+    echo "xdebug.profiler_output_dir='/var/www/html/_profiles'" >> /usr/local/etc/php/conf.d/xdebug.ini
+    echo 'max_execution_time=100' >> /usr/local/etc/php/conf.d/xdebug.ini
   fi
 `);
 


### PR DESCRIPTION
Adds an env var flag that configures PHP to allow profiling requests.

If the PHP request receives a GET/POST var named "XDEBUG_PROFILE", xdebug will output a cachegrind file to `_profiles` within the Drupal/WP container.

To be configured by https://github.com/forumone/forumone-cli/pull/99