### PR TITLE
Fix eslint error format in gulp webpack task.

### DIFF
--- a/src/app/plugins/platform/JavaScript/templates/tasks/webpack.js
+++ b/src/app/plugins/platform/JavaScript/templates/tasks/webpack.js
@@ -6,6 +6,6 @@ module.exports = async function webpackBuild() {
   const webpackConfig = require('../webpack.config')({mode: 'production'});
   const stats = await asyncWebpack(webpackConfig);
   if (stats.hasErrors()) {
-    throw new Error(stats.compilation.errors.map(i => i.rawMessage).join('\n'));
+    throw new Error(stats.compilation.errors.map(err => err.rawMessage).join('\n'));
   }
 };

--- a/src/app/plugins/platform/JavaScript/templates/tasks/webpack.js
+++ b/src/app/plugins/platform/JavaScript/templates/tasks/webpack.js
@@ -6,6 +6,6 @@ module.exports = async function webpackBuild() {
   const webpackConfig = require('../webpack.config')({mode: 'production'});
   const stats = await asyncWebpack(webpackConfig);
   if (stats.hasErrors()) {
-    throw new Error(stats.compilation.errors.join('\n'));
+    throw new Error(stats.compilation.errors.map(i => i.rawMessage).join('\n'));
   }
 };


### PR DESCRIPTION
Was getting errors in this format:
[18:26:02] Using gulpfile ~/Desktop/AFP-GDash-2019/services/wordpress/web/js/chart/gulpfile.js
[18:26:02] Starting 'build'...
Starting type checking service...
[18:26:12] 'build' errored after 9.87 s
[18:26:12] Error: [object Object]
[object Object]
[object Object]
[object Object]
[object Object]
[object Object]
[object Object]
[object Object]
[object Object]
[object Object]