### PR TITLE
Bump TypeScript version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,8 @@ steps:
   - label: ':hammer: Build'
     command:
       - npm ci
-      - npm pack
+      # Allow npm to pack the tarball as root in this container
+      - npm pack --unsafe-perm
     plugins:
       - docker#v3.3.0:
           image: 'node:10'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9827,9 +9827,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "jest": "24.9.0",
     "prettier": "1.15.3",
     "ts-jest": "24.1.0",
-    "typescript": "3.2.2"
+    "typescript": "^3.3.4000"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
This PR works around a newly-discovered issue in TypeScript that causes an out-of-memory issue during the `npm pack` script. I discovered that we didn't catch this on Buildkite because the Docker image was running without the `--unsafe-perm` flag, causing npm to skip the prepack script that invoked Gulp.

I've made a relatively minor bump to TypeScript; we should investigate bumping to the latest version at some later point.