### PR TITLE
Fix incorrect target for WP images

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -193,7 +193,7 @@ class WordPress extends Generator {
     ].join('\n');
 
     editor.addService('wordpress', {
-      build: './services/wordpress',
+      build: { context: './services/wordpress', target: 'dev' },
       depends_on: ['mysql'],
       command: ['-c', wpEntryCommand],
       entrypoint: '/bin/sh',


### PR DESCRIPTION
This PR defaults WordPress image builds to the `dev` target to align with Drupal.

(Jira: DEVTOOLS-448)