### PR TITLE
WSGEN-18: Multistage Dockerfile Revisions

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/createDrupalDockerfile.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/createDrupalDockerfile.ts
@@ -75,6 +75,11 @@ function createDrupalDockerfile({
     sourceFiles,
   });
 
+  dockerfile.addTestCopyStage({
+    buildDirectories: ['scripts', 'vendor', documentRoot],
+    gessoPath,
+  });
+
   return dockerfile;
 }
 

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/createWordPressDockerfile.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/createWordPressDockerfile.ts
@@ -70,13 +70,22 @@ function createWordPressDockerfile({
 
   const buildDirectories = composer ? [documentRoot] : undefined;
 
-  return dockerfile
+  // Create the release stage.
+  dockerfile
     .addFinalCopyStage({
       buildDirectories,
       gessoPath,
       sourceDirectories: [documentRoot],
     })
     .run(moveDockerfile);
+
+  // Create the test stage.
+  dockerfile.addTestCopyStage({
+    buildDirectories,
+    gessoPath,
+  });
+
+  return dockerfile;
 }
 
 export default createWordPressDockerfile;


### PR DESCRIPTION
Jira Ticket: WSGEN-18

### Changes

- [x] Rename `deps` stage to `composer` for clarity
- [x] Copy additional required files into this stage to ensure Composer scripts may be executed
    - [x] `scripts/` directory
    - [x] `load.environment.php` file if it is required for autoload in `composer.json`
- [x] Add a secondary `composer-dev` stage to install additional dev dependencies for testing
- [x] Move `node_modules` directory removal step to a separate `gesso-clean` stage to keep them available without reinstalling for the `gesso-dev` stage
- [x] Label the production-ready image as `release`
- [x] Add an additional `test` stage to pull in additional dev dependencies required for CI testing operations
- [x] Maintain the `release` stage as the default build with a final `FROM release` line along with appropriate commentary for clarity of purpose