### PR TITLE
Update ruby gem versions for json and i18n gems.

### DIFF
--- a/src/app/plugins/Capistrano/templates/Gemfile
+++ b/src/app/plugins/Capistrano/templates/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'capistrano', '3.4'
-gem 'json', '~>1.8'
-gem 'i18n', '~>0.8.6'
+gem 'json', '~>2.3.1'
+gem 'i18n', '~>1.8.5'


### PR DESCRIPTION
Update to latest releases for json and i18n Ruby gems to address
security vulnerabilities. Updates beyond v3.4 of Capistrano fail due to
our deployment configuration with the custom rysnc SCM plugin which is
entirely deprecated and unsupported after v3.6.

See https://github.com/capistrano/capistrano/blob/v3.7.0/UPGRADING-3.7.md