### PR TITLE
Align xdebug profiler test variable with f1 cli usage.

### DIFF
--- a/src/app/plugins/platform/Docker/xdebug.ts
+++ b/src/app/plugins/platform/Docker/xdebug.ts
@@ -10,7 +10,7 @@ export const enableXdebug = dedent(`
 
 // http://xdebug.org/docs/all_settings#profiler_enable_trigger
 export const enableXdebugProfiler = dedent(`
-  if test ! -z "\${F1_XDEBUG_PROFILER:-}"; then
+  if test ! -z "\${F1_XDEBUG_PROFILE:-}"; then
     docker-php-ext-enable xdebug
     if test ! -d "/var/www/html/_profiles"; then
       mkdir /var/www/html/_profiles


### PR DESCRIPTION
The test for the Xdebug Profiler feature added as part of
pull request #221 included a typo resulting in a misalignment
with the usage of `f1 up --xdebug-profile` and not triggering
configuration of the profiler as expected.