### PR TITLE
WSGEN-30: default name & default entry node

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/search/Elasticsearch.ts
+++ b/src/app/plugins/platform/Docker/plugins/search/Elasticsearch.ts
@@ -54,7 +54,7 @@ class ElasticSearch extends Generator {
         name: 'esTag',
         type: 'list',
         choices: this.esTagOptions,
-        message: 'Choose an ElasticSearch version:',
+        message: 'Choose an Elasticsearch version:',
         store: true,
       },
     ]);
@@ -108,7 +108,8 @@ class ElasticSearch extends Generator {
         cluster.name: "docker-cluster"
         network.host: 0.0.0.0
         discovery.seed_hosts : []
-        cluster.initial_master_nodes : []
+        cluster.initial_master_nodes: elasticsearch
+        node.name: elasticsearch
       `,
     );
   }


### PR DESCRIPTION
Also corrected case of Elasticsearch.