### PR TITLE
Remove the prepareForPantheon step for new Drupal Pantheon projects.

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
@@ -155,12 +155,6 @@ async function installDrupal({
     case drupalProject:
       await spawnComposer(['composer', 'drupal:scaffold'], { cwd: drupalRoot });
       break;
-
-    case pantheonProject:
-      await spawnComposer(['composer', 'prepare-for-pantheon'], {
-        cwd: drupalRoot,
-      });
-      break;
   }
 }
 


### PR DESCRIPTION
Jira Ticket: WSGEN-33

Remove the call to the prepareForPantheon script for new Pantheon Drupal
projects since this should only be run in CI processes preparing to
deploy to the Pantheon repository. If this is run during the install
phase the gitignore file is modified to capture all build assets.