### PR TITLE
WSGEN-32: Composer 2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,21 @@ npx --ignore-existing -p yo -p generator-web-starter yo web-starter
 - `npm pack` - Create a tarball for testing purposes
 - `npx -p <path to generator.tgz> -p yo -- yo web-starter`  - Execute web starter with the modifications you just made
 - Review input / output after making selections that you're testing for and ensure changes are captured
+
+## Debugging
+
+To support easier debugging, verbose logging may be enabled during execution using the [logging mechanism built into
+Yeoman](https://yeoman.io/authoring/debugging.html) by default. Logging for any specified generator may be done by
+setting various values into the `DEBUG` environment variable before execution.
+
+For all logging:
+```bash
+export DEBUG=\*
+```
+
+For more targeted debugging within a given generator or sub-generator other values may be set including:
+
+* Everything: `DEBUG=\*`
+* Yeoman generator flow: `DEBUG='yeoman:generator'`
+* Main app generator: `DEBUG='web-starter:app'`
+* All Web Starter sub-generators: `DEBUG='web-starter:*'`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4914,11 +4914,18 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "debug-fabulous": {
@@ -5705,7 +5712,7 @@
         },
         "mute-stream": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
           "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
           "dev": true
         },
@@ -5984,6 +5991,14 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -9401,7 +9416,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -10440,7 +10455,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -10667,7 +10682,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -11216,6 +11231,14 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -11507,7 +11530,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -11546,7 +11569,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -12554,7 +12577,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/semver": "~5.5.0",
     "assert-plus": "~1.0.0",
     "d3-array": "~2.0.3",
+    "debug": "^4.3.1",
     "decompress": "~4.2.1",
     "dedent": "~0.7.0",
     "dockerfilejs": "^1.2.1",

--- a/src/app/plugins/platform/Docker/dockerfile/constants.ts
+++ b/src/app/plugins/platform/Docker/dockerfile/constants.ts
@@ -1,12 +1,12 @@
 /**
  * Currently-supported Composer version.
  */
-export const composerTag = '1.9';
+export const composerTag = '2';
 
 /**
  * The name of the Composer image to use for projects.
  */
-export const composerImage = 'forumone/composer';
+export const composerImage = 'composer';
 
 /**
  * The full `<image>:<tag>` string for this image; useful for `docker run` or the `image:`

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -301,6 +301,7 @@ class Drupal8 extends Generator {
     await this._installDrupal();
 
     if (this.useGesso) {
+      this.debug('Installing Gesso dependencies.');
       await this._installGessoDependencies();
     }
   }
@@ -327,32 +328,50 @@ class Drupal8 extends Generator {
       tag: this.latestDrushTag,
     });
 
+    this.debug(
+      'Writing Drupal Dockerfile to %s.',
+      'services/drupal/Dockerfile',
+    );
     this.fs.write(
       this.destinationPath('services/drupal/Dockerfile'),
       drupalDockerfile.render(),
     );
 
+    this.debug('Writing Drush Dockerfile to %s.', 'services/drush/Dockerfile');
     this.fs.write(
       this.destinationPath('services/drush/Dockerfile'),
       drushDockerfile.render(),
     );
 
+    this.debug(
+      'Adding contents of %s to the .dockerignore file.',
+      'services/drupal/.gitignore',
+    );
     const drupalDockerIgnore = new IgnoreEditor();
     drupalDockerIgnore.addContentsOfFile({
       heading: 'Drupal 8',
       content: this.fs.read(this.destinationPath('services/drupal/.gitignore')),
     });
 
+    this.debug(
+      'Writing .dockerignore file to %s.',
+      'services/drupal/.gitignore',
+    );
     this.fs.write(
       this.destinationPath('services/drupal/.dockerignore'),
       drupalDockerIgnore.serialize(),
     );
 
+    this.debug('Copying .env template file to %s.', 'services/drupal/.env');
     this.fs.copy(
       this.templatePath('_env'),
       this.destinationPath('services/drupal/.env'),
     );
 
+    this.debug(
+      'Writing .gitkeep file to %s.',
+      'services/drupal/config/.gitkeep',
+    );
     this.fs.write(
       this.destinationPath('services/drupal/config/.gitkeep'),
       configGitKeepContents,

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -49,6 +49,11 @@ class Drupal8 extends Generator {
       getLatestDrupal8Tag(),
       getLatestDrupal8CliTag(),
     ]);
+    this.debug(
+      'Loaded latest Drupal (%s) and Drush (%s) tags.',
+      latestDrupalTag,
+      latestDrushTag,
+    );
 
     this.latestDrupalTag = latestDrupalTag;
     this.latestDrushTag = latestDrushTag;
@@ -127,7 +132,7 @@ class Drupal8 extends Generator {
     this.useGesso = useGesso;
 
     if (useCapistrano) {
-      this.composeWith(this.options.capistrano, {
+      const capistranoOptions = {
         platform: 'drupal8',
         name: this.options.name,
         webroot: documentRoot,
@@ -139,15 +144,28 @@ class Drupal8 extends Generator {
           posix.join('services/drupal', documentRoot, 'sites/default/files'),
         ],
         linkedFiles: ['services/drupal/.env'],
-      });
+      };
+      this.debug(
+        'Composing with Capistrano generator using options: %O',
+        capistranoOptions,
+      );
+      this.composeWith(this.options.capistrano, capistranoOptions);
     }
 
     if (useGesso) {
-      this.composeWith(require.resolve('../../gesso/GessoDrupal8'), {
+      const gessoOptions = {
         documentRoot: this.documentRoot,
         composeEditor: this.options.composeEditor,
         composeCliEditor: this.options.composeCliEditor,
-      });
+      };
+      this.debug(
+        'Composing with Gesso generator using options: %O',
+        gessoOptions,
+      );
+      this.composeWith(
+        require.resolve('../../gesso/GessoDrupal8'),
+        gessoOptions,
+      );
     }
   }
 
@@ -252,6 +270,7 @@ class Drupal8 extends Generator {
       return;
     }
 
+    this.debug('Triggering Drupal installation process.');
     await installDrupal({
       documentRoot: this.documentRoot,
       projectType: this.projectType,
@@ -265,7 +284,9 @@ class Drupal8 extends Generator {
     }
 
     // Install required dependencies to avoid Gesso crashing when enabled
+    // @todo [WSGEN-38] Consolidate dependency installation into one call.
     for (const dependency of gessoDrupalDependencies) {
+      this.debug('Adding Gesso Composer dependency: %s', dependency);
       await spawnComposer(['require', dependency, '--ignore-platform-reqs'], {
         cwd: this.destinationPath('services/drupal'),
       });

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
@@ -3,6 +3,7 @@ import makeDir from 'make-dir';
 import path from 'path';
 import rimraf from 'rimraf';
 import { promisify } from 'util';
+import createDebugger from 'debug';
 
 import spawnComposer from '../../../spawnComposer';
 
@@ -13,6 +14,11 @@ export const pantheonProject = 'pantheon-systems/example-drops-8-composer';
 export type PantheonProject = typeof pantheonProject;
 
 export type Project = PantheonProject | DrupalProject;
+
+// Define the debugging namespace to align with other debugger output.
+const debugNamespace =
+  'web-starter:app:plugins:platform:Docker:plugins:cms:Drupal8:installDrupal';
+const debug = createDebugger(debugNamespace);
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -67,6 +73,8 @@ async function injectPlatformConfig(composerPath: string) {
     platform[`ext-${extension}`] = '1.0.0';
   }
 
+  // @todo [WSGEN-1] Fix JSON formatting for the written composer.json file.
+  debug('Rewriting composer file %s with added platform configuration.');
   await writeFile(composerPath, JSON.stringify(composer), 'utf-8');
 }
 
@@ -96,8 +104,10 @@ async function installDrupal({
     );
   }
 
+  debug('Making service directory %s.', serviceDirectory);
   await makeDir(serviceDirectory);
 
+  debug('Executing composer create-project.');
   await spawnComposer(
     [
       'create-project',
@@ -115,6 +125,7 @@ async function installDrupal({
 
   // Rename 'web' in generated files, if we need to
   if (needsRename) {
+    debug('Replacing docroot references from %s to %s.', 'web', documentRoot);
     await Promise.all([
       replaceIn(
         path.join(drupalRoot, 'composer.json'),
@@ -153,6 +164,7 @@ async function installDrupal({
   // to the Docker entrypoint.
   switch (projectType) {
     case drupalProject:
+      debug('Executing drupal:scaffold Composer command.');
       await spawnComposer(['composer', 'drupal:scaffold'], { cwd: drupalRoot });
       break;
 

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/createComposerFile.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/createComposerFile.ts
@@ -69,7 +69,7 @@ function createComposerFile(name: string, documentRoot: string): ComposerFile {
   }
 
   return {
-    name,
+    name: `forumone/${name}`,
     type: 'project',
     repositories: [{ type: 'composer', url: 'https://wpackagist.org' }],
     require: {

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -115,6 +115,10 @@ class WordPress extends Generator {
     this.usesGesso = useGesso;
 
     if (useCapistrano) {
+      this.debug(
+        'Composing with Capistrano generator using options: %O',
+        this.options.capistrano,
+      );
       this.composeWith(this.options.capistrano, {
         platform: 'wordpress',
         name: this.options.name,
@@ -133,15 +137,27 @@ class WordPress extends Generator {
     }
 
     if (useGesso) {
-      this.composeWith(require.resolve('../../gesso/GessoWordPress'), {
+      const gessoOptions = {
         documentRoot: this.documentRoot,
         composeEditor: this.options.composeEditor,
         composeCliEditor: this.options.composeCliEditor,
-      });
+      };
+      this.debug(
+        'Composing with Gesso generator with options: %O',
+        gessoOptions,
+      );
+      this.composeWith(
+        require.resolve('../../gesso/GessoWordPress'),
+        gessoOptions,
+      );
     }
   }
 
   configuring() {
+    this.debug(
+      'Copying nginx config template to %s.',
+      'services/nginx/default.conf',
+    );
     this.fs.copyTpl(
       this.templatePath('nginx.conf.ejs'),
       this.destinationPath('services/nginx/default.conf'),
@@ -162,6 +178,7 @@ class WordPress extends Generator {
     //   Needed so that we can persist saved files across containers.
     const filesystemVolume = editor.ensureVolume('fs-data');
 
+    this.debug('Adding Nginx service.');
     editor.addNginxService({
       depends_on: ['wordpress'],
       volumes: [
@@ -180,7 +197,7 @@ class WordPress extends Generator {
       ],
     });
 
-    // Set up the environment variables to be read in config
+    // Set up the environment variables to be read in config.
     const initialEnvironment = {
       DB_HOST: 'mysql:3306',
       DB_NAME: 'web',
@@ -198,6 +215,7 @@ class WordPress extends Generator {
       'exec php-fpm',
     ].join('\n');
 
+    this.debug('Adding wordpress service.');
     editor.addService('wordpress', {
       build: { context: './services/wordpress', target: 'dev' },
       depends_on: ['mysql'],
@@ -217,11 +235,15 @@ class WordPress extends Generator {
       ],
     });
 
+    this.debug('Adding MySQL service.');
     editor.addMysqlService();
+
+    this.debug('Adding Mailhog service.');
     editor.addMailhogService();
 
     const cliEditor = this.options.composeCliEditor as ComposeEditor;
 
+    this.debug('Adding wp-cli service.');
     cliEditor.addService('wp', {
       build: './services/wp-cli',
       volumes: [
@@ -235,6 +257,7 @@ class WordPress extends Generator {
     });
 
     if (this.usesWpStarter) {
+      this.debug('Adding composer cli service.');
       cliEditor.addComposer('services/wordpress');
     }
   }
@@ -243,6 +266,7 @@ class WordPress extends Generator {
     // For project not using wp-starter, don't bother writing out composer.json
     // or a .env file.
     if (this.usesWpStarter) {
+      this.debug('Rewriting services/wordpress/composer.json.');
       this.fs.extendJSON(
         this.destinationPath('services/wordpress/composer.json'),
         createComposerFile(this.options.name, this.documentRoot),
@@ -250,11 +274,13 @@ class WordPress extends Generator {
 
       const dotenvPath = this.destinationPath('services/wordpress/.env');
       if (!this.fs.exists(dotenvPath)) {
+        this.debug('Copying .env template to %s.', dotenvPath);
         this.fs.copy(this.templatePath('_env'), dotenvPath);
       }
 
       const prodEnvPath = `${dotenvPath}.production`;
       if (!this.fs.exists(prodEnvPath)) {
+        this.debug('Copying .env.production template to %s.', prodEnvPath);
         this.fs.copy(this.templatePath('_env.production'), prodEnvPath);
       }
     } else {
@@ -265,6 +291,7 @@ class WordPress extends Generator {
       );
 
       if (!this.fs.exists(wpConfigPath)) {
+        this.debug('Copying wp-config.php template to %s.', wpConfigPath);
         this.fs.copyTpl(this.templatePath('wp-config.php.ejs'), wpConfigPath, {
           hashes: await getHashes(),
         });
@@ -281,6 +308,9 @@ class WordPress extends Generator {
       composer: Boolean(this.usesWpStarter),
     });
 
+    this.debug(
+      'Writing WordPress Dockerfile to services/wordpress/Dockerfile.',
+    );
     this.fs.write(
       this.destinationPath('services/wordpress/Dockerfile'),
       wpDockerfile.render(),
@@ -291,13 +321,15 @@ class WordPress extends Generator {
       memcached: needsMemcached,
     });
 
+    this.debug('Writing wp-cli Dockerfile to services/wp-cli/Dockerfile.');
     this.fs.write(
       this.destinationPath('services/wp-cli/Dockerfile'),
       cliDockerfile.render(),
     );
 
-    // For projects NOT using the web-starter, add a wp-cli.yml file.
+    // For projects NOT using the WPStarter, add a wp-cli.yml file.
     if (!this.usesWpStarter) {
+      this.debug('Creating wp-cli.yml file since WpStarter is not being used.');
       this.fs.copyTpl(
         this.templatePath('wp-cli-nostarter.yml.ejs'),
         this.destinationPath('services/wordpress/wp-cli.yml'),
@@ -313,6 +345,7 @@ class WordPress extends Generator {
 
     if (this.usesWpStarter) {
       const wpRoot = this.destinationPath('services/wordpress');
+      this.debug('Spawning Composer install command in %s.', wpRoot);
       await spawnComposer(['install'], { cwd: wpRoot });
     } else {
       const wpRoot = this.destinationPath(
@@ -320,6 +353,7 @@ class WordPress extends Generator {
         this.documentRoot,
       );
 
+      this.debug('Installing WordPress source in %s.', wpRoot);
       await installWordPressSource(wpRoot);
     }
   }
@@ -328,18 +362,21 @@ class WordPress extends Generator {
    * Install plugin from WordPress Packagist with Composer.
    */
   private async _installWithComposer(pluginName: string) {
-    await spawnComposer(
-      ['require', `wpackagist-plugin/${pluginName}`, '--ignore-platform-reqs'],
-      {
-        cwd: this.destinationPath('services/wordpress'),
-      },
+    const packageName = `wpackagist-plugin/${pluginName}`;
+    this.debug(
+      'Spawning Composer command to install WordPress plugin %s.',
+      packageName,
     );
+    await spawnComposer(['require', packageName, '--ignore-platform-reqs'], {
+      cwd: this.destinationPath('services/wordpress'),
+    });
   }
 
   /**
    * Install plugin from WordPress plugin repo as a zip.
    */
   private async _installFromWPRepo(pluginName: string) {
+    this.debug('Installing plugin %s from repo.', pluginName);
     const endpoint = new URL('https://downloads.wordpress.org');
     endpoint.pathname = posix.join('plugin', `${pluginName}.latest-stable.zip`);
     const response = await fetch(String(endpoint));
@@ -359,6 +396,11 @@ class WordPress extends Generator {
       pluginName,
     );
 
+    this.debug(
+      'Decompressing downloaded plugin from %s to %s.',
+      endpoint.pathname,
+      destinationPath,
+    );
     await decompress(buffer, destinationPath, { strip: 1 });
   }
 
@@ -371,20 +413,23 @@ class WordPress extends Generator {
       ? pluginName => this._installWithComposer(pluginName)
       : pluginName => this._installFromWPRepo(pluginName);
 
-    // Install required dependencies to avoid Gesso crashing when enabled
+    // Install required dependencies to avoid Gesso crashing when enabled.
     for (const plugin of gessoWPDependencies) {
+      this.debug('Installing Gesso dependency %s.', plugin);
       await install(plugin);
     }
   }
 
   async install() {
+    this.debug('Installing WordPress.');
     await this._installWordPress();
 
     if (this.usesGesso) {
+      this.debug('Installing Gesso dependencies.');
       await this._installGessoDependencies();
     }
 
-    // Create the .dockerignore file here, after everything has been installed
+    // Create the .dockerignore file here, after everything has been installed.
     const wpIgnorePath = this.destinationPath('services/wordpress/.gitignore');
 
     const gitignoreEditor = new IgnoreEditor();
@@ -396,6 +441,7 @@ class WordPress extends Generator {
     }
 
     // Append the additional gitignore entries to the WordPress service gitignore file.
+    this.debug('Writing gitignore file to %s.', wpIgnorePath);
     this.fs.write(
       this.destinationPath(wpIgnorePath),
       gitignoreEditor.serialize(),
@@ -410,10 +456,18 @@ class WordPress extends Generator {
 
       if (this.usesGesso) {
         const path = posix.join(this.documentRoot, 'wp-content/themes/gesso');
+        this.debug(
+          'Adding Gesso path %s as exception to .dockerignore file.',
+          path,
+        );
         ignoreEditor.addEntry(`!${path}`);
       }
     }
 
+    this.debug(
+      'Writing .dockerignore file to %s.',
+      'services/wordpress/.dockerignore',
+    );
     this.fs.write(
       this.destinationPath('services/wordpress/.dockerignore'),
       ignoreEditor.serialize(),


### PR DESCRIPTION
JIRA Ticket: WSGEN-32

The goal of this PR is to implement Composer 2 usage and support into newly generated projects. The generator should also be able to be run on top of existing projects and apply related changes for manual review to update existing projects.

Changes included:
* Added significantly more debug logging and documentation
* Updated Docker images to use the Docker Hub's `composer:2` image
  * This deprecates the usage of the `forumone/composer` image
* Apply a `forumone/{project name}` namespace to generated `composer.json` files for WordPress projects
  * This is required for Composer 2 support and will need to be manually added to updating projects