### PR TITLE
WSGEN-1: Format composer.json file output when it is rewritten.

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
@@ -67,7 +67,7 @@ async function injectPlatformConfig(composerPath: string) {
     platform[`ext-${extension}`] = '1.0.0';
   }
 
-  await writeFile(composerPath, JSON.stringify(composer), 'utf-8');
+  await writeFile(composerPath, JSON.stringify(composer, null, 4), 'utf-8');
 }
 
 export interface InstallDrupalOptions {


### PR DESCRIPTION
JIRA Ticket: WSGEN-1

The composer.json file is rewritten during the setup process when
platform dependencies are added. This was resulting in poorly formatted
files since the stringify method wasn't intentionally formatting the
output to the file.

**Note**: This is a replacement for pull request #344 that added unnecessary dependencies.