### PR TITLE
WSGEN-38: Consolidate Composer Install Commands During Drupal Setup

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -313,6 +313,13 @@ class Drupal8 extends Generator {
       this.debug('Installing Gesso dependencies.');
       await this._installGessoDependencies();
     }
+
+    // Run final installation of all Composer dependencies now that all
+    // requirements have been assembled.
+    this.debug('Running final Composer installation.');
+    await spawnComposer(['install', '--ignore-platform-reqs'], {
+      cwd: this.destinationPath('services/drupal'),
+    });
   }
 
   writing() {

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -287,9 +287,12 @@ class Drupal8 extends Generator {
     // @todo [WSGEN-38] Consolidate dependency installation into one call.
     for (const dependency of gessoDrupalDependencies) {
       this.debug('Adding Gesso Composer dependency: %s', dependency);
-      await spawnComposer(['require', dependency, '--ignore-platform-reqs'], {
-        cwd: this.destinationPath('services/drupal'),
-      });
+      await spawnComposer(
+        ['require', dependency, '--ignore-platform-reqs', '--no-install'],
+        {
+          cwd: this.destinationPath('services/drupal'),
+        },
+      );
     }
   }
 

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -284,16 +284,22 @@ class Drupal8 extends Generator {
     }
 
     // Install required dependencies to avoid Gesso crashing when enabled
-    // @todo [WSGEN-38] Consolidate dependency installation into one call.
-    for (const dependency of gessoDrupalDependencies) {
-      this.debug('Adding Gesso Composer dependency: %s', dependency);
-      await spawnComposer(
-        ['require', dependency, '--ignore-platform-reqs', '--no-install'],
-        {
-          cwd: this.destinationPath('services/drupal'),
-        },
-      );
-    }
+    this.debug(
+      'Adding Gesso Composer dependencies: %s',
+      gessoDrupalDependencies.join(', '),
+    );
+    await spawnComposer(
+      [
+        'require',
+        ...gessoDrupalDependencies,
+        '--ignore-platform-reqs',
+        '--no-scripts',
+        '--no-install',
+      ],
+      {
+        cwd: this.destinationPath('services/drupal'),
+      },
+    );
   }
 
   // We have to run the drupal installation here because drupal-scaffold will fail if the target

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
@@ -156,27 +156,6 @@ async function installDrupal({
 
   // Inject platform configuration to the generated composer.json file.
   await injectPlatformConfig(path.join(drupalRoot, 'composer.json'));
-
-  // Make sure the lock file is up to date.
-  // await spawnComposer(['update', '--lock', '--no-install'], {
-  //   cwd: drupalRoot,
-  // });
-
-  // Perform project-specific operations.
-  // NB. We have to specify the 'composer' command explicitly, as these aren't known
-  // to the Docker entrypoint.
-  // switch (projectType) {
-  //   case drupalProject:
-  //     debug('Executing drupal:scaffold Composer command.');
-  //     await spawnComposer(['drupal:scaffold'], { cwd: drupalRoot });
-  //     break;
-
-  //   case pantheonProject:
-  //     await spawnComposer(['prepare-for-pantheon'], {
-  //       cwd: drupalRoot,
-  //     });
-  //     break;
-  // }
 }
 
 export default installDrupal;

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/installDrupal.ts
@@ -117,6 +117,7 @@ async function installDrupal({
       'dev',
       '--no-interaction',
       '--ignore-platform-reqs',
+      '--no-install',
     ],
     { cwd: serviceDirectory },
   );
@@ -157,23 +158,25 @@ async function installDrupal({
   await injectPlatformConfig(path.join(drupalRoot, 'composer.json'));
 
   // Make sure the lock file is up to date.
-  await spawnComposer(['update', '--lock'], { cwd: drupalRoot });
+  // await spawnComposer(['update', '--lock', '--no-install'], {
+  //   cwd: drupalRoot,
+  // });
 
   // Perform project-specific operations.
   // NB. We have to specify the 'composer' command explicitly, as these aren't known
   // to the Docker entrypoint.
-  switch (projectType) {
-    case drupalProject:
-      debug('Executing drupal:scaffold Composer command.');
-      await spawnComposer(['composer', 'drupal:scaffold'], { cwd: drupalRoot });
-      break;
+  // switch (projectType) {
+  //   case drupalProject:
+  //     debug('Executing drupal:scaffold Composer command.');
+  //     await spawnComposer(['drupal:scaffold'], { cwd: drupalRoot });
+  //     break;
 
-    case pantheonProject:
-      await spawnComposer(['composer', 'prepare-for-pantheon'], {
-        cwd: drupalRoot,
-      });
-      break;
-  }
+  //   case pantheonProject:
+  //     await spawnComposer(['prepare-for-pantheon'], {
+  //       cwd: drupalRoot,
+  //     });
+  //     break;
+  // }
 }
 
 export default installDrupal;


### PR DESCRIPTION
JIRA Ticket: WSGEN-38

**Note**: This PR is dependent on Composer 2 and is built on top of pull request #345 which should be resolved first.

During the creation of a Drupal project, various composer commands preparing the project were resulting in repetitive install operations that are processor and time-intensive. Upgrading to Composer 2 adds support for a `--no-install` flag on several Composer commands which allows for consolidation of this execution.

Introduced Changes:
• Composer create-project command skips installation of dependencies
* Gesso dependency installation is consolidated to a single Composer command
* Skip installation during the addition of Gesso dependencies
* Execute a final Composer install command once manipulation of the `composer.json` file is completed
* Remove post-install `drupal:scaffold` and `prepare-for-pantheon` commands
  * `drupal:scaffold` is incorporated in post-install hooks following migration into the drupal/core-composer-scaffold project
  * The `prepare-for-pantheon` command should only be run in CI processes to expose generated dependencies for commit to version control