### PR TITLE
Store the selected Drupal project target.

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -109,6 +109,7 @@ class Drupal8 extends Generator {
         type: 'list',
         name: 'drupalProjectType',
         message: 'Select project type to install:',
+        store: true,
         // NB. `as' casts below needed to dodge a deficiency in the Inquirer types
         // (they don't know about the 'choice' property)
         choices: [


### PR DESCRIPTION
A simple change, but I'm unaware of any reason _not_ to store the project type selection which allows for re-running the generator consistently.