### PR TITLE
Add option to skip `composer install` after scaffolding is completed

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -103,7 +103,6 @@ class Drupal8 extends Generator {
 
           return !this.fs.exists(targetPath);
         },
-        when: !this.options.skipInstall,
       },
       {
         type: 'list',

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -315,12 +315,18 @@ class Drupal8 extends Generator {
       await this._installGessoDependencies();
     }
 
-    // Run final installation of all Composer dependencies now that all
-    // requirements have been assembled.
-    this.debug('Running final Composer installation.');
-    await spawnComposer(['install', '--ignore-platform-reqs'], {
-      cwd: this.destinationPath('services/drupal'),
-    });
+    if (!this.options.skipInstall) {
+      // Run final installation of all Composer dependencies now that all
+      // requirements have been assembled.
+      this.debug('Running final Composer installation.');
+      await spawnComposer(['install', '--ignore-platform-reqs'], {
+        cwd: this.destinationPath('services/drupal'),
+      });
+    } else {
+      this.debug(
+        'Skipping final Composer installation due to `--skip-install` option.',
+      );
+    }
   }
 
   writing() {


### PR DESCRIPTION
Since the final installation of Composer dependencies was split to an independent operation in pull request #347, this update enables usage of the `--skip-install` flag to automatically bypass that installation.

**Changed Behavior:** Previously the `--skip-install` flag prevented the question of whether to install Drupal and selection of the project profile altogether, but this behavior may still be accomplished by selecting not to install Drupal at the related prompt.