### PR TITLE
Fix missing namespacing for "latest" image tags in Buildkite.

### DIFF
--- a/src/buildkite-pipeline/templates/pipeline.yml.ejs
+++ b/src/buildkite-pipeline/templates/pipeline.yml.ejs
@@ -44,10 +44,10 @@ steps:
           # These images are attempted to pull in sequence up to the first
           # success, and any failures don't prevent further build steps.
           cache-from:
-            # Pull the test images since this should also contain the prior steps
-            # used to build the release image.
+            - release:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_COMMIT
+            - release:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-latest
             - test:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_COMMIT
-            - test:$IMAGE_REPOSITORY:latest
+            - test:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-latest
           build:
             - test
             - release
@@ -57,9 +57,9 @@ steps:
           build-parallel: true
           # Upload commit-specific image tags for clarity and caching support.
           push:
-            - test:$IMAGE_REPOSITORY:latest
+            - test:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-latest
             - test:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_COMMIT
-            - release:$IMAGE_REPOSITORY:latest
+            - release:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-latest
             - release:$IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_COMMIT
 
   # Wait for completion of the previous build steps.


### PR DESCRIPTION
Enable image caching benefits for new commits using caches from the
latest builds for that project by applying a "latest" tag for each
build. Ensuring it is properly namespaced helps to make sure conflicts
across projects don't impact caching benefits.