### PR TITLE
Add uninteractive execution support for App and Cap Stage generators.

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -19,8 +19,8 @@ class WebStarter extends Generator {
 
     this.option('uninteractive', {
       type: Boolean,
-      description: 'Prevent all prompts and use saved answers.',
       default: false,
+      description: 'Prevent all prompts and use saved answers.',
     });
   }
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -28,7 +28,7 @@ class WebStarter extends Generator {
     const platformDirectory = path.join(__dirname, 'plugins/platform');
     const platforms = await discoverModules(platformDirectory);
 
-    const { name, platform } = await this._promptOrUninteractive([
+    const { name, platform } = await promptOrUninteractive.call(this, [
       {
         type: 'input',
         name: 'name',
@@ -86,19 +86,6 @@ class WebStarter extends Generator {
       name: this.name,
       private: true,
     });
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
-    );
   }
 }
 

--- a/src/app/plugins/Capistrano/index.ts
+++ b/src/app/plugins/Capistrano/index.ts
@@ -1,4 +1,5 @@
 import Generator from 'yeoman-generator';
+import { promptOrUninteractive } from '../../../util';
 
 class Capistrano extends Generator {
   private deployMethod!: string;
@@ -10,7 +11,7 @@ class Capistrano extends Generator {
   }
 
   async configuring() {
-    const answers = await this.prompt([
+    const answers = await promptOrUninteractive.call(this, [
       {
         type: 'list',
         name: 'capistranoDeployMethod',

--- a/src/app/plugins/platform/Docker/index.ts
+++ b/src/app/plugins/platform/Docker/index.ts
@@ -2,6 +2,7 @@ import assert from 'assert-plus';
 import dedent from 'dedent';
 import path from 'path';
 import Generator from 'yeoman-generator';
+import { promptOrUninteractive } from '../../../../util';
 
 import discoverModules from '../../../discoverModules';
 import IgnoreEditor from '../../../IgnoreEditor';
@@ -33,7 +34,12 @@ class Docker extends Generator {
   private readonly editor = new ComposeEditor({ intro: composeIntro });
   private readonly cliEditor = new ComposeEditor({ intro: cliIntro });
 
-  initializing() {
+  public constructor(
+    args: string | string[],
+    opts: Generator.GeneratorOptions,
+  ) {
+    super(args, opts);
+
     const options = this.options;
     assert.string(options.name, 'options.name');
     assert.string(options.capistrano, 'options.capistrano');
@@ -51,7 +57,11 @@ class Docker extends Generator {
     const cachePluginDirectory = path.join(pluginDirectory, 'cache');
     const cachePlugins = await discoverModules(cachePluginDirectory);
 
-    const answers = await this.prompt([
+    const {
+      [cmsAnswerKey]: cmsType,
+      [searchAnswerKey]: searchType,
+      [cacheAnswerKey]: cacheType,
+    } = await this._promptOrUninteractive([
       {
         type: 'list',
         name: cmsAnswerKey,
@@ -75,16 +85,11 @@ class Docker extends Generator {
       },
     ]);
 
-    const {
-      [cmsAnswerKey]: cmsType,
-      [searchAnswerKey]: searchType,
-      [cacheAnswerKey]: cacheType,
-    } = answers;
-
     const composedGeneratorOptions = {
       cliConfigEditor: this.options.cliConfigEditor,
       composeEditor: this.editor,
       composeCliEditor: this.cliEditor,
+      uninteractive: this.options.uninteractive,
       plugins: {
         cms: cmsType,
         search: searchType,
@@ -146,6 +151,19 @@ class Docker extends Generator {
         new ComposeEditor({ intro: overrideIntro }).serialize(),
       );
     }
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
+    );
   }
 }
 

--- a/src/app/plugins/platform/Docker/index.ts
+++ b/src/app/plugins/platform/Docker/index.ts
@@ -61,7 +61,7 @@ class Docker extends Generator {
       [cmsAnswerKey]: cmsType,
       [searchAnswerKey]: searchType,
       [cacheAnswerKey]: cacheType,
-    } = await this._promptOrUninteractive([
+    } = await promptOrUninteractive.call(this, [
       {
         type: 'list',
         name: cmsAnswerKey,
@@ -151,19 +151,6 @@ class Docker extends Generator {
         new ComposeEditor({ intro: overrideIntro }).serialize(),
       );
     }
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
-    );
   }
 }
 

--- a/src/app/plugins/platform/Docker/plugins/cache/Redis.ts
+++ b/src/app/plugins/platform/Docker/plugins/cache/Redis.ts
@@ -1,5 +1,6 @@
 import { descending } from 'd3-array';
 import Generator from 'yeoman-generator';
+import { promptOrUninteractive } from '../../../../../../util';
 
 import ComposeEditor from '../../ComposeEditor';
 import getImageTags from '../../registry/getImageTags';
@@ -26,7 +27,7 @@ class Redis extends Generator {
   }
 
   async prompting() {
-    const { redisTag } = await this.prompt([
+    const { redisTag } = await this._promptOrUninteractive([
       {
         name: 'redisTag',
         type: 'list',
@@ -51,6 +52,19 @@ class Redis extends Generator {
       image,
       entrypoint: ['redis-cli', '-h', 'redis'],
     });
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
+    );
   }
 }
 

--- a/src/app/plugins/platform/Docker/plugins/cache/Redis.ts
+++ b/src/app/plugins/platform/Docker/plugins/cache/Redis.ts
@@ -27,7 +27,7 @@ class Redis extends Generator {
   }
 
   async prompting() {
-    const { redisTag } = await this._promptOrUninteractive([
+    const { redisTag } = await promptOrUninteractive.call(this, [
       {
         name: 'redisTag',
         type: 'list',
@@ -52,19 +52,6 @@ class Redis extends Generator {
       image,
       entrypoint: ['redis-cli', '-h', 'redis'],
     });
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
-    );
   }
 }
 

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -22,6 +22,7 @@ import createDrupalDockerfile from './createDrupalDockerfile';
 import createDrushDockerfile from './createDrushDockerfile';
 import dedent from 'dedent';
 import { gessoDrupalPath } from '../../gesso/constants';
+import { promptOrUninteractive } from '../../../../../../../util';
 
 const gessoDrupalDependencies: ReadonlyArray<string> = [
   'drupal/components',
@@ -67,7 +68,7 @@ class Drupal8 extends Generator {
       useGesso,
       shouldInstallDrupal,
       drupalProjectType,
-    } = await this.prompt([
+    } = await this._promptOrUninteractive([
       {
         type: 'input',
         name: 'documentRoot',
@@ -145,6 +146,7 @@ class Drupal8 extends Generator {
           posix.join('services/drupal', documentRoot, 'sites/default/files'),
         ],
         linkedFiles: ['services/drupal/.env'],
+        uninteractive: this.options.uninteractive,
       };
       this.debug(
         'Composing with Capistrano generator using options: %O',
@@ -158,6 +160,7 @@ class Drupal8 extends Generator {
         documentRoot: this.documentRoot,
         composeEditor: this.options.composeEditor,
         composeCliEditor: this.options.composeCliEditor,
+        uninteractive: this.options.uninteractive,
       };
       this.debug(
         'Composing with Gesso generator using options: %O',
@@ -447,6 +450,19 @@ class Drupal8 extends Generator {
         documentRoot: this.documentRoot,
         inheritedRules: drupalDockerIgnore.serialize(),
       },
+    );
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
     );
   }
 }

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -68,7 +68,7 @@ class Drupal8 extends Generator {
       useGesso,
       shouldInstallDrupal,
       drupalProjectType,
-    } = await this._promptOrUninteractive([
+    } = await promptOrUninteractive.call(this, [
       {
         type: 'input',
         name: 'documentRoot',
@@ -450,19 +450,6 @@ class Drupal8 extends Generator {
         documentRoot: this.documentRoot,
         inheritedRules: drupalDockerIgnore.serialize(),
       },
-    );
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
     );
   }
 }

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -57,7 +57,7 @@ class WordPress extends Generator {
       shouldInstallWordPress,
       useGesso,
       useCapistrano,
-    } = await this._promptOrUninteractive([
+    } = await promptOrUninteractive.call(this, [
       {
         type: 'input',
         name: 'documentRoot',
@@ -503,19 +503,6 @@ class WordPress extends Generator {
         },
       ],
       templateVars,
-    );
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
     );
   }
 }

--- a/src/app/plugins/platform/Docker/plugins/gesso/createGessoGenerator.ts
+++ b/src/app/plugins/platform/Docker/plugins/gesso/createGessoGenerator.ts
@@ -1,6 +1,7 @@
 import assert from 'assert-plus';
 import { posix } from 'path';
 import Generator from 'yeoman-generator';
+import { promptOrUninteractive } from '../../../../../../util';
 
 import ComposeEditor, {
   createBindMount,
@@ -71,12 +72,13 @@ function createGessoGenerator({
       assert.string(options.documentRoot, 'options.documentRoot');
       assert.object(options.composeEditor, 'options.composeEditor');
       assert.object(options.composeCliEditor, 'options.composeCliEditor');
+      assert.bool(options.uninteractive, 'options.uninteractive');
 
       this.documentRoot = options.documentRoot;
     }
 
     async prompting() {
-      const { gessoShouldInstall } = await this.prompt([
+      const { gessoShouldInstall } = await this._promptOrUninteractive([
         {
           type: 'confirm',
           name: 'gessoShouldInstall',
@@ -188,6 +190,19 @@ function createGessoGenerator({
       if (installPhase === 'install') {
         return this._installGesso();
       }
+    }
+
+    /**
+     * Shortcut the promptOrUninteractive call with prefilled arguments.
+     *
+     * @param prompts
+     */
+    private async _promptOrUninteractive(prompts: Generator.Questions) {
+      return await promptOrUninteractive(
+        prompts,
+        this.options.uninteractive,
+        this,
+      );
     }
   }
 

--- a/src/app/plugins/platform/Docker/plugins/gesso/createGessoGenerator.ts
+++ b/src/app/plugins/platform/Docker/plugins/gesso/createGessoGenerator.ts
@@ -78,7 +78,7 @@ function createGessoGenerator({
     }
 
     async prompting() {
-      const { gessoShouldInstall } = await this._promptOrUninteractive([
+      const { gessoShouldInstall } = await promptOrUninteractive.call(this, [
         {
           type: 'confirm',
           name: 'gessoShouldInstall',
@@ -190,19 +190,6 @@ function createGessoGenerator({
       if (installPhase === 'install') {
         return this._installGesso();
       }
-    }
-
-    /**
-     * Shortcut the promptOrUninteractive call with prefilled arguments.
-     *
-     * @param prompts
-     */
-    private async _promptOrUninteractive(prompts: Generator.Questions) {
-      return await promptOrUninteractive(
-        prompts,
-        this.options.uninteractive,
-        this,
-      );
     }
   }
 

--- a/src/app/plugins/platform/Docker/plugins/search/Elasticsearch.ts
+++ b/src/app/plugins/platform/Docker/plugins/search/Elasticsearch.ts
@@ -34,7 +34,7 @@ class ElasticSearch extends Generator {
   }
 
   async prompting() {
-    const { esTag } = await this._promptOrUninteractive([
+    const { esTag } = await promptOrUninteractive.call(this, [
       {
         name: 'esTag',
         type: 'list',
@@ -96,19 +96,6 @@ class ElasticSearch extends Generator {
         cluster.initial_master_nodes: elasticsearch
         node.name: elasticsearch
       `,
-    );
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
     );
   }
 }

--- a/src/app/plugins/platform/Docker/plugins/search/Elasticsearch.ts
+++ b/src/app/plugins/platform/Docker/plugins/search/Elasticsearch.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent';
 import Generator from 'yeoman-generator';
+import { promptOrUninteractive } from '../../../../../../util';
 
 import ComposeEditor, { createBindMount } from '../../ComposeEditor';
 import { AnyService } from '../../ComposeEditor/ComposeFile';
@@ -33,7 +34,7 @@ class ElasticSearch extends Generator {
   }
 
   async prompting() {
-    const { esTag } = await this.prompt([
+    const { esTag } = await this._promptOrUninteractive([
       {
         name: 'esTag',
         type: 'list',
@@ -95,6 +96,19 @@ class ElasticSearch extends Generator {
         cluster.initial_master_nodes: elasticsearch
         node.name: elasticsearch
       `,
+    );
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
     );
   }
 }

--- a/src/app/plugins/platform/Docker/plugins/search/Solr.ts
+++ b/src/app/plugins/platform/Docker/plugins/search/Solr.ts
@@ -1,6 +1,7 @@
 import { descending } from 'd3-array';
 import dedent from 'dedent';
 import Generator from 'yeoman-generator';
+import { promptOrUninteractive } from '../../../../../../util';
 
 import ComposeEditor, { createBindMount } from '../../ComposeEditor';
 import getImageTags from '../../registry/getImageTags';
@@ -47,7 +48,7 @@ class Solr extends Generator {
   }
 
   async prompting() {
-    const { solrTag } = await this.prompt([
+    const { solrTag } = await this._promptOrUninteractive([
       {
         name: 'solrTag',
         type: 'list',
@@ -82,6 +83,19 @@ class Solr extends Generator {
     this.fs.write(
       this.destinationPath('services/solr/conf/.gitkeep'),
       gitKeepMessage,
+    );
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
     );
   }
 }

--- a/src/app/plugins/platform/Docker/plugins/search/Solr.ts
+++ b/src/app/plugins/platform/Docker/plugins/search/Solr.ts
@@ -48,7 +48,7 @@ class Solr extends Generator {
   }
 
   async prompting() {
-    const { solrTag } = await this._promptOrUninteractive([
+    const { solrTag } = await promptOrUninteractive.call(this, [
       {
         name: 'solrTag',
         type: 'list',
@@ -83,19 +83,6 @@ class Solr extends Generator {
     this.fs.write(
       this.destinationPath('services/solr/conf/.gitkeep'),
       gitKeepMessage,
-    );
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
     );
   }
 }

--- a/src/app/plugins/platform/JavaScript/index.ts
+++ b/src/app/plugins/platform/JavaScript/index.ts
@@ -18,7 +18,7 @@ class JavaScript extends Generator {
   }
 
   async prompting() {
-    const { useCapistrano } = await this._promptOrUninteractive([
+    const { useCapistrano } = await promptOrUninteractive.call(this, [
       {
         type: 'confirm',
         name: 'useCapistrano',
@@ -173,19 +173,6 @@ class JavaScript extends Generator {
 
     this._installToolchain();
     this._installDependencies();
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
-    );
   }
 }
 

--- a/src/app/plugins/platform/JavaScript/index.ts
+++ b/src/app/plugins/platform/JavaScript/index.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util';
 import Generator from 'yeoman-generator';
 
 import IgnoreEditor from '../../../IgnoreEditor';
+import { promptOrUninteractive } from '../../../../util';
 
 const readFile = promisify(fs.readFile);
 
@@ -13,10 +14,11 @@ class JavaScript extends Generator {
     const options = this.options;
     assert.object(options.gitignoreEditor, 'options.gitignoreEditor');
     assert.string(options.capistrano, 'options.capistrano');
+    assert.bool(options.uninteractive, 'options.uninteractive');
   }
 
   async prompting() {
-    const { useCapistrano } = await this.prompt([
+    const { useCapistrano } = await this._promptOrUninteractive([
       {
         type: 'confirm',
         name: 'useCapistrano',
@@ -32,6 +34,7 @@ class JavaScript extends Generator {
         name: this.options.name,
         webroot: 'public',
         appWebroot: 'public',
+        uninteractive: this.options.uninteractive,
       });
     }
   }
@@ -170,6 +173,19 @@ class JavaScript extends Generator {
 
     this._installToolchain();
     this._installDependencies();
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
+    );
   }
 }
 

--- a/src/buildkite-pipeline/index.ts
+++ b/src/buildkite-pipeline/index.ts
@@ -53,8 +53,8 @@ class BuildkitePipeline extends ManifestAwareGenerator {
 
     this.option('uninteractive', {
       type: Boolean,
-      description: 'Prevent all prompts and use saved answers.',
       default: false,
+      description: 'Prevent all prompts and use saved answers.',
     });
   }
 

--- a/src/buildkite-pipeline/index.ts
+++ b/src/buildkite-pipeline/index.ts
@@ -11,6 +11,7 @@ import {
   ManifestAwareGenerator,
   ManifestAwareOptions,
 } from '../manifest/manifestAwareGenerator';
+import { promptOrUninteractive } from '../util';
 
 interface BranchMapping {
   readonly source: string;
@@ -35,15 +36,26 @@ interface PipelineTemplateData {
   };
 }
 
+interface BuildkitePipelineOptions extends ManifestAwareOptions {
+  /** Prevent all prompts and use saved answers. */
+  uninteractive: boolean;
+}
+
 class BuildkitePipeline extends ManifestAwareGenerator {
   private deployments: DeploymentCollection;
   private answers: Generator.Answers;
 
-  constructor(args: string | string[], options: ManifestAwareOptions) {
+  constructor(args: string | string[], options: BuildkitePipelineOptions) {
     super(args, options);
 
     this.deployments = this.manifest.deployments || {};
     this.answers = {};
+
+    this.option('uninteractive', {
+      type: Boolean,
+      description: 'Prevent all prompts and use saved answers.',
+      default: false,
+    });
   }
 
   /**
@@ -57,7 +69,7 @@ class BuildkitePipeline extends ManifestAwareGenerator {
    * Execute the configuration phase of this generator.
    */
   async prompting() {
-    const answers = await this.prompt([
+    const answers = await this._promptOrUninteractive([
       {
         name: 'serviceDirectory',
         message: 'What directory is the application in?',
@@ -258,6 +270,19 @@ class BuildkitePipeline extends ManifestAwareGenerator {
     }
 
     return Object.keys(branches).length ? { branches } : undefined;
+  }
+
+  /**
+   * Shortcut the promptOrUninteractive call with prefilled arguments.
+   *
+   * @param prompts
+   */
+  private async _promptOrUninteractive(prompts: Generator.Questions) {
+    return await promptOrUninteractive(
+      prompts,
+      this.options.uninteractive,
+      this,
+    );
   }
 }
 

--- a/src/buildkite-pipeline/index.ts
+++ b/src/buildkite-pipeline/index.ts
@@ -69,7 +69,7 @@ class BuildkitePipeline extends ManifestAwareGenerator {
    * Execute the configuration phase of this generator.
    */
   async prompting() {
-    const answers = await this._promptOrUninteractive([
+    const answers = await promptOrUninteractive.call(this, [
       {
         name: 'serviceDirectory',
         message: 'What directory is the application in?',
@@ -270,19 +270,6 @@ class BuildkitePipeline extends ManifestAwareGenerator {
     }
 
     return Object.keys(branches).length ? { branches } : undefined;
-  }
-
-  /**
-   * Shortcut the promptOrUninteractive call with prefilled arguments.
-   *
-   * @param prompts
-   */
-  private async _promptOrUninteractive(prompts: Generator.Questions) {
-    return await promptOrUninteractive(
-      prompts,
-      this.options.uninteractive,
-      this,
-    );
   }
 }
 

--- a/src/cap-stage/index.ts
+++ b/src/cap-stage/index.ts
@@ -19,8 +19,8 @@ class CapStage extends Generator {
 
     this.option('uninteractive', {
       type: Boolean,
-      description: 'Prevent all prompts and use saved answers.',
       default: false,
+      description: 'Prevent all prompts and use saved answers.',
     });
   }
 

--- a/src/cap-stage/index.ts
+++ b/src/cap-stage/index.ts
@@ -11,6 +11,19 @@ interface StageDefinition {
 }
 
 class CapStage extends Generator {
+  public constructor(
+    args: string | string[],
+    opts: Generator.GeneratorOptions,
+  ) {
+    super(args, opts);
+
+    this.option('uninteractive', {
+      type: Boolean,
+      description: 'Prevent all prompts and use saved answers.',
+      default: false,
+    });
+  }
+
   async configuring() {
     const projectName = this.config.get('projectName');
     assert.string(projectName, 'config.projectName');

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,30 +1,33 @@
 import Generator from 'yeoman-generator';
 import chalk from 'chalk';
+import assert from 'assert-plus';
 
 /**
  * Interactively prompt with generator questions or return configured answers.
  *
  * @param prompts
- * @param uninteractive
- * @param generator
  */
 export async function promptOrUninteractive(
+  this: Generator,
   prompts: Generator.Questions,
-  uninteractive: boolean,
-  generator: Generator,
 ): Promise<Generator.Answers> {
+  assert.bool(
+    this.options.uninteractive,
+    'Expected Boolean uninteractive generator options.',
+  );
+
   let answers: Generator.Answers = {};
 
-  if (!uninteractive) {
-    generator.debug('Interactively prompting for options.');
-    answers = await generator.prompt(prompts);
+  if (!this.options.uninteractive) {
+    this.debug('Interactively prompting for options.');
+    answers = await this.prompt(prompts);
   } else {
-    const config = generator.config.get('promptValues');
+    const config = this.config.get('promptValues');
 
     // Log assumed prompt responses for debugging.
     for (const prompt of Object.values(prompts)) {
       const cachedValue = config[prompt.name];
-      generator.debug(
+      this.debug(
         chalk`Assuming uninteractive value for {bold '%s'}: {bold.green %s}`,
         prompt.name,
         cachedValue,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,37 @@
+import Generator from 'yeoman-generator';
+import chalk from 'chalk';
+
+/**
+ * Interactively prompt with generator questions or return configured answers.
+ *
+ * @param prompts
+ * @param uninteractive
+ * @param generator
+ */
+export async function promptOrUninteractive(
+  prompts: Generator.Questions,
+  uninteractive: boolean,
+  generator: Generator,
+): Promise<Generator.Answers> {
+  let answers: Generator.Answers = {};
+
+  if (!uninteractive) {
+    generator.debug('Interactively prompting for options.');
+    answers = await generator.prompt(prompts);
+  } else {
+    const config = generator.config.get('promptValues');
+
+    // Log assumed prompt responses for debugging.
+    for (const prompt of Object.values(prompts)) {
+      const cachedValue = config[prompt.name];
+      generator.debug(
+        chalk`Assuming uninteractive value for {bold '%s'}: {bold.green %s}`,
+        prompt.name,
+        cachedValue,
+      );
+      answers[prompt.name] = cachedValue;
+    }
+  }
+
+  return answers;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,7 +20,7 @@ export async function promptOrUninteractive(
 
   if (!this.options.uninteractive) {
     this.debug('Interactively prompting for options.');
-    answers = await this.prompt(prompts);
+    answers = this.prompt(prompts);
   } else {
     const config = this.config.get('promptValues');
 


### PR DESCRIPTION
Generators may be executed with the `--uninteractive` flag to
automatically use previously configured answers stored within the
`promptValues` key in `.yo-rc.json`.