### PR TITLE
Default new projects being created to use `web` as the web root.

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal8/index.ts
@@ -85,7 +85,7 @@ class Drupal8 extends Generator {
         name: 'documentRoot',
         validate: name => name !== '' && validFilename(name),
         message: 'What is the document root?',
-        default: 'public',
+        default: 'web',
         store: true,
       },
       {

--- a/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
+++ b/src/app/plugins/platform/Docker/plugins/cms/WordPress/index.ts
@@ -65,7 +65,7 @@ class WordPress extends Generator {
         name: 'documentRoot',
         validate: name => name !== '' && validFilename(name),
         message: 'What is the document root?',
-        default: 'public',
+        default: 'web',
         store: true,
       },
       {

--- a/test/d8-standard/.yo-rc.json
+++ b/test/d8-standard/.yo-rc.json
@@ -6,7 +6,7 @@
       "dockerCms": "Drupal8",
       "dockerSearch": "None",
       "dockerCache": "None",
-      "documentRoot": "public",
+      "documentRoot": "web",
       "useGesso": true,
       "useCapistrano": false,
       "shouldInstallDrupal": true,


### PR DESCRIPTION
Replace `public` with `web` as the default web root name for new
projects in order to bring about more consistency with projects hosted
at F1 or Pantheon.