### PR TITLE
Fine-tune linting with Gesso

### DIFF
--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal/templates/_codacy.yml.ejs
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal/templates/_codacy.yml.ejs
@@ -51,3 +51,7 @@ exclude_paths:
   - 'services/drupal/scripts/composer/ScriptHandler.php'
   - 'services/drupal/web/sites/default/settings.pantheon.php'
   <%_ } _%>
+  <%_ if (useGesso) { _%>
+  # Ignore issues pre-existing within Gesso third-party libraries or forks.
+  - 'services/drupal/<%= documentRoot %>/themes/gesso/js/libraries/*'
+  <%_ } _%>

--- a/src/app/plugins/platform/Docker/plugins/cms/Drupal/templates/_codacy.yml.ejs
+++ b/src/app/plugins/platform/Docker/plugins/cms/Drupal/templates/_codacy.yml.ejs
@@ -9,6 +9,9 @@ engines:
     php_version: 7.4
     base_sub_dir: services/drupal
   <%_ if (useGesso) { _%>
+    # Let ESLint rather than PHPMD handle JS linting in Gesso.
+    exclude_paths:
+      - services/drupal/<%= documentRoot %>/themes/gesso/**/*.js
   eslint:
     enabled: true
     # Restrict parsing into the Gesso directory where a config file exists.


### PR DESCRIPTION
Excludes Gesso JS files from PHPMD linting. Those are already covered by ESLint, and was finding on PIIE D9 that PHPMD gets tripped up by some ES6+ features and reports issues where there are none. Also excludes the Gesso libraries folder from Codacy altogether, as those are third-party libraries.